### PR TITLE
Add System enviorment support for language and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ To get a localized result, e.g. in Swedish use the -l flag.
 $ wiki -l sv ruby
 ```
 
+or using System Enviroment:
+
+```shell
+$ WIKI_LANG="sv" wiki ruby
+```
+
 Use the -h flag to see all options (or `man wiki` if you have it installed)
 
 ```shell
@@ -97,11 +103,18 @@ E.g. for bash. Add an alias to your `.bash_profile` or `.bashrc` file.
 ```bash
 alias uwiki='wiki -u https://en.wikiversity.org/w/api.php '
 ```
-
 And call it using
 
 ```shell
 $ uwiki physics
+```
+
+or using System Enviroment in your `.bash_profile` or `.bashrc`file.
+
+```bash
+echo "export WIKI_URL=https://en.wikiversity.org/w/api.php" >> .bashrc
+# reload shell / source .bashrc
+wiki physics
 ```
 
 ## Testing

--- a/_doc/wiki.1
+++ b/_doc/wiki.1
@@ -46,5 +46,17 @@ Outputs help information and exists
 .TP
 .BR \-version "
 Outputs version information and exists
+.SH ENVIRONMENT
+Setting any of this variables will override the default application values.
+.TP
+.BR WIKI_LANG
+Override default LANGUAGE
+.TP
+.BR WIKI_URL
+Override default URL
+.SH EXAMPLES
+WIKI_LANG=sv wiki Software
+
+WIKI_URL=https://wiki.secret-stuff.com/w/api.php wiki SecretSystem
 .SH AUTHOR
 Fredrik Wallgren (fredrik.wallgren@gmail.com)

--- a/cmd/wiki/main.go
+++ b/cmd/wiki/main.go
@@ -30,8 +30,18 @@ Options:
 		flag.PrintDefaults()
 	}
 
-	language := flag.String("l", "en", "The language to use")
-	url := flag.String("u", "https://%s.wikipedia.org/w/api.php", "The api url")
+	def_lang := os.Getenv("WIKI_LANG")
+	def_url := os.Getenv("WIKI_URL")
+
+	if def_lang == "" {
+		def_lang = "en"
+	}
+	if def_url == "" {
+		def_url = "https://%s.wikipedia.org/w/api.php"
+	}
+
+	language := flag.String("l", def_lang, "The language to use")
+	url := flag.String("u", def_url, "The api url")
 	noColor := flag.Bool("n", false, "If the output should not be colorized")
 	simple := flag.Bool("s", false, "If simple output should be used")
 	short := flag.Bool("short", false, "If short output should be used")

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -48,7 +48,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
 if [ $? -ne 0 ];then
-  fail 'Standard usage did not output link to page' 
+  fail 'Standard usage did not output link to page'
 fi
 pass
 
@@ -61,7 +61,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
 if [ $? -eq 0 ];then
-  fail 'Short flag did output link to page' 
+  fail 'Short flag did output link to page'
 fi
 pass
 
@@ -74,7 +74,20 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
 if [ $? -ne 0 ];then
-  fail 'Language flag did not work' 
+  fail 'Language flag did not work'
+fi
+pass
+
+# Test that language enviroment works
+OUTPUT="$(WIKI_LANG=sv $BIN c++)"
+STATUS=$?
+if [[ $STATUS -ne 0 ]]; then
+  fail 'Did not get success exit code'
+  exit 1
+fi
+echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
+if [ $? -ne 0 ];then
+  fail 'Language flag did not work'
 fi
 pass
 
@@ -87,7 +100,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "\[32m"
 if [ $? -eq 0 ];then
-  fail 'No color flag did not work' 
+  fail 'No color flag did not work'
 fi
 pass
 
@@ -100,7 +113,20 @@ if [[ $STATUS -eq 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
 if [ $? -ne 0 ];then
-  fail 'Url flag did not work' 
+  fail 'Url flag did not work'
+fi
+pass
+
+#Test URL passed as enviroment
+OUTPUT="$(WIKI_URL=http://localhost:8080/w/api.php $BIN golang 2>&1)"
+STATUS=$?
+if [[ $STATUS -eq 0 ]]; then
+  fail 'Got success exit code'
+  exit 1
+fi
+echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
+if [ $? -ne 0 ];then
+  fail 'Url flag did not work'
 fi
 pass
 
@@ -113,7 +139,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
 if [ $? -ne 0 ];then
-  fail 'Standard usage did not output link to page' 
+  fail 'Standard usage did not output link to page'
 fi
 pass
 
@@ -124,9 +150,9 @@ if [[ $STATUS -ne 0 ]]; then
   fail 'Did not get success exit code'
   exit 1
 fi
-OUTPUT2="echo "$OUTPUT" | grep -c '.'"
+OUTPUT2="$(echo $OUTPUT | grep -c '.')"
 if [ $OUTPUT2 -ne 1 ];then
-  fail 'Short flag did not work' 
+  fail 'Short flag did not work'
 fi
 pass
 


### PR DESCRIPTION
Default language and api URL can be override by System Enviorments so
the user don't have to use command arguments.
