### PR TITLE
Autodetect test cases in integration tests suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ To get a localized result, e.g. in Swedish use the -l flag.
 $ wiki -l sv ruby
 ```
 
+or using System Enviroment:
+
+```shell
+$ WIKI_LANG="sv" wiki ruby
+```
+
 Use the -h flag to see all options (or `man wiki` if you have it installed)
 
 ```shell
@@ -97,11 +103,18 @@ E.g. for bash. Add an alias to your `.bash_profile` or `.bashrc` file.
 ```bash
 alias uwiki='wiki -u https://en.wikiversity.org/w/api.php '
 ```
-
 And call it using
 
 ```shell
 $ uwiki physics
+```
+
+or using System Enviroment in your `.bash_profile` or `.bashrc`file.
+
+```bash
+echo "export WIKI_URL=https://en.wikiversity.org/w/api.php" >> .bashrc
+# reload shell / source .bashrc
+wiki physics
 ```
 
 ## Testing

--- a/_doc/wiki.1
+++ b/_doc/wiki.1
@@ -46,5 +46,17 @@ Outputs help information and exists
 .TP
 .BR \-version "
 Outputs version information and exists
+.SH ENVIRONMENT
+Setting any of this variables will override the default application values.
+.TP
+.BR WIKI_LANG
+Override default LANGUAGE
+.TP
+.BR WIKI_URL
+Override default URL
+.SH EXAMPLES
+WIKI_LANG=sv wiki Software
+
+WIKI_URL=https://wiki.secret-stuff.com/w/api.php wiki SecretSystem
 .SH AUTHOR
 Fredrik Wallgren (fredrik.wallgren@gmail.com)

--- a/cmd/wiki/main.go
+++ b/cmd/wiki/main.go
@@ -30,8 +30,18 @@ Options:
 		flag.PrintDefaults()
 	}
 
-	language := flag.String("l", "en", "The language to use")
-	url := flag.String("u", "https://%s.wikipedia.org/w/api.php", "The api url")
+	def_lang := os.Getenv("WIKI_LANG")
+	def_url := os.Getenv("WIKI_URL")
+
+	if def_lang == "" {
+		def_lang = "en"
+	}
+	if def_url == "" {
+		def_url = "https://%s.wikipedia.org/w/api.php"
+	}
+
+	language := flag.String("l", def_lang, "The language to use")
+	url := flag.String("u", def_url, "The api url")
 	noColor := flag.Bool("n", false, "If the output should not be colorized")
 	simple := flag.Bool("s", false, "If simple output should be used")
 	short := flag.Bool("short", false, "If short output should be used")

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -48,7 +48,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
 if [ $? -ne 0 ];then
-  fail 'Standard usage did not output link to page' 
+  fail 'Standard usage did not output link to page'
 fi
 pass
 
@@ -61,7 +61,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
 if [ $? -eq 0 ];then
-  fail 'Short flag did output link to page' 
+  fail 'Short flag did output link to page'
 fi
 pass
 
@@ -74,7 +74,20 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
 if [ $? -ne 0 ];then
-  fail 'Language flag did not work' 
+  fail 'Language flag did not work'
+fi
+pass
+
+# Test that language enviroment works
+OUTPUT="$(WIKI_LANG=sv $BIN c++)"
+STATUS=$?
+if [[ $STATUS -ne 0 ]]; then
+  fail 'Did not get success exit code'
+  exit 1
+fi
+echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
+if [ $? -ne 0 ];then
+  fail 'Language flag did not work'
 fi
 pass
 
@@ -87,7 +100,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "\[32m"
 if [ $? -eq 0 ];then
-  fail 'No color flag did not work' 
+  fail 'No color flag did not work'
 fi
 pass
 
@@ -100,7 +113,20 @@ if [[ $STATUS -eq 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
 if [ $? -ne 0 ];then
-  fail 'Url flag did not work' 
+  fail 'Url flag did not work'
+fi
+pass
+
+#Test URL passed as enviroment
+OUTPUT="$(WIKI_URL=http://localhost:8080/w/api.php $BIN golang 2>&1)"
+STATUS=$?
+if [[ $STATUS -eq 0 ]]; then
+  fail 'Got success exit code'
+  exit 1
+fi
+echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
+if [ $? -ne 0 ];then
+  fail 'Url flag did not work'
 fi
 pass
 
@@ -113,7 +139,7 @@ if [[ $STATUS -ne 0 ]]; then
 fi
 echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
 if [ $? -ne 0 ];then
-  fail 'Standard usage did not output link to page' 
+  fail 'Standard usage did not output link to page'
 fi
 pass
 
@@ -124,9 +150,9 @@ if [[ $STATUS -ne 0 ]]; then
   fail 'Did not get success exit code'
   exit 1
 fi
-OUTPUT2="echo "$OUTPUT" | grep -c '.'"
+OUTPUT2="$(echo $OUTPUT | grep -c '.')"
 if [ $OUTPUT2 -ne 1 ];then
-  fail 'Short flag did not work' 
+  fail 'Short flag did not work'
 fi
 pass
 

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 
+BASEFILE=$0
+TESTS=""
 # Keep track of failures
 FAILED=0
 
+# Bin to use in tests
+BIN=./build/wiki
+
+# Setup all test functions that should be executed.
+# All function starting with the word "test" will be part of the test suite.
+function getTests() {
+  for i in `cat $BASEFILE | sed -n "/^function test/s/function \([a-zA-Z0-9_]*\).*/\1/p"`; do
+    TESTS="$TESTS $i"
+  done
+}
+
 # Output a fail message
-fail() {
+function fail() {
   echo ''
   echo 'FAIL'
   echo $1
@@ -12,12 +25,13 @@ fail() {
 }
 
 # Show progress when tests pass
-pass() {
+function pass() {
   echo -n '.'
 }
 
+
 # Output a message and return with no error when all tests has passed
-finished() {
+function finished() {
   echo ''
   if [[ $FAILED -ne 0 ]]; then
     echo 'There were failed integration tests'
@@ -27,133 +41,149 @@ finished() {
   exit $FAILED
 }
 
-# Bin to use in tests
-BIN=./build/wiki
-
 # Test that error message and usage is printed if no query
-$BIN > /dev/null 2>&1
-STATUS=$?
-if [[ $STATUS -ne 1 ]]; then
-  fail 'Error message and usage not printed if no output'
-  exit 1
-fi
-pass
+function testNoArguments() {
+  $BIN > /dev/null 2>&1
+  STATUS=$?
+  if [[ $STATUS -ne 1 ]]; then
+    fail 'Error message and usage not printed if no output'
+  fi
+  pass
+}
 
 # Test that standard usage prints a link to page
-OUTPUT="$($BIN golang)"
-STATUS=$?
-if [[ $STATUS -ne 0 ]]; then
-  fail 'Did not get success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
-if [ $? -ne 0 ];then
-  fail 'Standard usage did not output link to page'
-fi
-pass
+function testSimpleSearch() {
+  OUTPUT="$($BIN golang)"
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    fail 'Did not get success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
+  if [ $? -ne 0 ];then
+    fail 'Standard usage did not output link to page'
+  fi
+  pass
+}
 
 # Test that short flag does not print a link to page
-OUTPUT="$($BIN -s golang)"
-STATUS=$?
-if [[ $STATUS -ne 0 ]]; then
-  fail 'Did not get success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
-if [ $? -eq 0 ];then
-  fail 'Short flag did output link to page'
-fi
-pass
+function testShortFlag() {
+  OUTPUT="$($BIN -s golang)"
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    fail 'Did not get success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
+  if [ $? -eq 0 ];then
+    fail 'Short flag did output link to page'
+  fi
+  pass
+}
 
 # Test that language flag works
-OUTPUT="$($BIN -l sv c++)"
-STATUS=$?
-if [[ $STATUS -ne 0 ]]; then
-  fail 'Did not get success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
-if [ $? -ne 0 ];then
-  fail 'Language flag did not work'
-fi
-pass
+function testLanguageFlag() {
+  OUTPUT="$($BIN -l sv c++)"
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    fail 'Did not get success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
+  if [ $? -ne 0 ];then
+    fail 'Language flag did not work'
+  fi
+  pass
+}
 
 # Test that language enviroment works
-OUTPUT="$(WIKI_LANG=sv $BIN c++)"
-STATUS=$?
-if [[ $STATUS -ne 0 ]]; then
-  fail 'Did not get success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
-if [ $? -ne 0 ];then
-  fail 'Language flag did not work'
-fi
-pass
+function testLanaguageEnv() {
+  OUTPUT="$(WIKI_LANG=sv $BIN c++)"
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    fail 'Did not get success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "Read more: https://sv.wikipedia.org/wiki/C"
+  if [ $? -ne 0 ];then
+    fail 'Language flag did not work'
+  fi
+  pass
+}
 
 # Test that no color flag works
-OUTPUT="$($BIN -n golang)"
-STATUS=$?
-if [[ $STATUS -ne 0 ]]; then
-  fail 'Did not get success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "\[32m"
-if [ $? -eq 0 ];then
-  fail 'No color flag did not work'
-fi
-pass
+function testNoColorFlag() {
+  OUTPUT="$($BIN -n golang)"
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    fail 'Did not get success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "\[32m"
+  if [ $? -eq 0 ];then
+    fail 'No color flag did not work'
+  fi
+  pass
+}
 
 # Test that url flag works
-OUTPUT="$($BIN -u http://localhost:8080/w/api.php golang 2>&1)"
-STATUS=$?
-if [[ $STATUS -eq 0 ]]; then
-  fail 'Got success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
-if [ $? -ne 0 ];then
-  fail 'Url flag did not work'
-fi
-pass
+function testURLFlag() {
+  OUTPUT="$($BIN -u http://localhost:8080/w/api.php golang 2>&1)"
+  STATUS=$?
+  if [[ $STATUS -eq 0 ]]; then
+    fail 'Got success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
+  if [ $? -ne 0 ];then
+    fail 'Url flag did not work'
+  fi
+  pass
+}
 
-#Test URL passed as enviroment
-OUTPUT="$(WIKI_URL=http://localhost:8080/w/api.php $BIN golang 2>&1)"
-STATUS=$?
-if [[ $STATUS -eq 0 ]]; then
-  fail 'Got success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
-if [ $? -ne 0 ];then
-  fail 'Url flag did not work'
-fi
-pass
+# Test URL passed as enviroment
+function testURLEnv () {
+  OUTPUT="$(WIKI_URL=http://localhost:8080/w/api.php $BIN golang 2>&1)"
+  STATUS=$?
+  if [[ $STATUS -eq 0 ]]; then
+    fail 'Got success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "Could not execute request Get http://localhost:8080"
+  if [ $? -ne 0 ];then
+    fail 'Url flag did not work'
+  fi
+  pass
+}
 
 # Test that no-check-certificate flag works
-OUTPUT="$($BIN -no-check-certificate golang)"
-STATUS=$?
-if [[ $STATUS -ne 0 ]]; then
-  fail 'Did not get success exit code'
-  exit 1
-fi
-echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
-if [ $? -ne 0 ];then
-  fail 'Standard usage did not output link to page'
-fi
-pass
+function testNoCheckCertificateFlag() {
+  OUTPUT="$($BIN -no-check-certificate golang)"
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    fail 'Did not get success exit code'
+  fi
+  echo "$OUTPUT" | grep -q "Read more: https://en.wikipedia.org/wiki/Go"
+  if [ $? -ne 0 ];then
+    fail 'Standard usage did not output link to page'
+  fi
+  pass
+}
 
 # Test that short flag works
-OUTPUT="$($BIN -short golang)"
-STATUS=$?
-if [[ $STATUS -ne 0 ]]; then
-  fail 'Did not get success exit code'
-  exit 1
-fi
-OUTPUT2="$(echo $OUTPUT | grep -c '.')"
-if [ $OUTPUT2 -ne 1 ];then
-  fail 'Short flag did not work'
-fi
-pass
+function testShortFlag2() {
+  OUTPUT="$($BIN -short golang)"
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    fail 'Did not get success exit code'
+  fi
+  OUTPUT2="$(echo $OUTPUT | grep -c '.')"
+  if [ $OUTPUT2 -ne 1 ];then
+    fail 'Short flag did not work'
+  fi
+  pass
+}
 
-finished
+function main() {
+  getTests
+
+  for t in $TESTS; do
+      $t
+  done
+  finished
+}
+
+main


### PR DESCRIPTION
Adding auto detection of new test case for the integration tests.

Moving all functions to separate function as an effort to isolate the different test cases from each other.
It will still not solve the problem with bash syntax error resulting in test "passed"
But will enable the possibility to verify that the number of executed test is aligned to number of passed and failed test as a future change.
